### PR TITLE
Fix types and export PluginError

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -115,16 +115,18 @@ export type PluginErrorOptions = Error & {
 };
 
 /**
- * A plugin error
- * @class
- * @constructor
- * @public
- *
- * @example
-import {gulpPlugin, PluginError} from 'gulp-plugin-extras';
+A plugin error.
+
+@class
+@constructor
+
+@example
+```
+import {PluginError} from 'gulp-plugin-extras';
 
 throw new PluginError('gulpFoo', 'Some error message');
- */
+```
+*/
 export class PluginError implements PluginErrorOptions {
 	plugin: string;
 	message: string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -117,9 +117,6 @@ export type PluginErrorOptions = Error & {
 /**
 A plugin error.
 
-@class
-@constructor
-
 @example
 ```
 import {PluginError} from 'gulp-plugin-extras';

--- a/index.d.ts
+++ b/index.d.ts
@@ -67,7 +67,11 @@ export default function gulpFoo() {
 }
 ```
 */
-export function gulpPlugin(name: string, onFile: (file: File) => File | Promise<File>, options?: Options): NodeJS.ReadableStream;
+export function gulpPlugin(
+	name: string,
+	onFile: (file: File) => File | Promise<File>,
+	options?: Options
+): NodeJS.ReadableStream;
 
 export type PluginErrorOptions = Error & {
 	/**
@@ -121,6 +125,18 @@ import {gulpPlugin, PluginError} from 'gulp-plugin-extras';
 
 throw new PluginError('gulpFoo', 'Some error message');
  */
-export class PluginError extends PluginErrorOptions {
+export class PluginError implements PluginErrorOptions {
+	plugin: string;
+	message: string;
+	name: string;
+	options_: PluginErrorOptions;
+	cause?: string;
+	error?: Error;
+	fileName?: string;
+	lineNumber?: number;
+	showProperties?: boolean;
+	showStack?: boolean;
+	stack?: string;
+
 	constructor(plugin: string | PluginErrorOptions, message: string | Error | PluginErrorOptions, options?: PluginErrorOptions);
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -137,5 +137,7 @@ export class PluginError implements PluginErrorOptions {
 	showStack?: boolean;
 	stack?: string;
 
-	constructor(plugin: string | PluginErrorOptions, message: string | Error | PluginErrorOptions, options?: PluginErrorOptions);
+	constructor(plugin: PluginErrorOptions);
+	constructor(plugin: string, message: PluginErrorOptions);
+	constructor(plugin: string, message: Error | string, options?: PluginErrorOptions);
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -137,7 +137,7 @@ export class PluginError implements PluginErrorOptions {
 	showStack?: boolean;
 	stack?: string;
 
-	constructor(plugin: PluginErrorOptions);
-	constructor(plugin: string, message: PluginErrorOptions);
+	constructor(options?: PluginErrorOptions);
+	constructor(plugin: string, options?: PluginErrorOptions);
 	constructor(plugin: string, message: Error | string, options?: PluginErrorOptions);
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -6,7 +6,7 @@ export type Options = {
 
 	@default false
 	*/
-	readonly supportsDirectories: boolean;
+	readonly supportsDirectories?: boolean;
 
 	/**
 	Whether the plugin can handle any Vinyl file type.
@@ -17,7 +17,7 @@ export type Options = {
 
 	@default false
 	*/
-	readonly supportsAnyType: boolean;
+	readonly supportsAnyType?: boolean;
 
 	/**
 	An async generator function executed for finalization after all files have been processed.
@@ -42,14 +42,16 @@ export type Options = {
 	}
 	```
 	*/
-	readonly onFinish?: (stream: NodeJS.ReadableStream) => AsyncGenerator<File.BufferFile>;
+	readonly onFinish?: (
+		stream: NodeJS.ReadableStream,
+	) => AsyncGenerator<File, never, void>;
 };
 
 /**
 Create a Gulp plugin.
 
 @param name - The plugin name.
-@param onFile - The async function called for each vinyl file in the stream. Must return a modified or new vinyl file.
+@param onFile - The function called for each vinyl file in the stream. Must return a modified or new vinyl file. May be async.
 
 If you throw an error with a `.isPresentable = true` property, it will not display the error stack.
 
@@ -69,6 +71,6 @@ export default function gulpFoo() {
 */
 export function gulpPlugin(
 	name: string,
-	onFile: (file: File.BufferFile) => Promise<File.BufferFile>,
-	options?: Options
+	onFile: (file: File) => File | Promise<File>,
+	options?: Options,
 ): NodeJS.ReadableStream;

--- a/index.d.ts
+++ b/index.d.ts
@@ -42,9 +42,7 @@ export type Options = {
 	}
 	```
 	*/
-	readonly onFinish?: (
-		stream: NodeJS.ReadableStream,
-	) => AsyncGenerator<File, never, void>;
+	readonly onFinish?: (stream: NodeJS.ReadableStream) => AsyncGenerator<File, never, void>;
 };
 
 /**
@@ -69,8 +67,60 @@ export default function gulpFoo() {
 }
 ```
 */
-export function gulpPlugin(
-	name: string,
-	onFile: (file: File) => File | Promise<File>,
-	options?: Options,
-): NodeJS.ReadableStream;
+export function gulpPlugin(name: string, onFile: (file: File) => File | Promise<File>, options?: Options): NodeJS.ReadableStream;
+
+export type PluginErrorOptions = Error & {
+	/**
+	The plugin name.
+	*/
+	plugin: string;
+
+	/**
+	Error cause indicating the reason why the current error is thrown.
+	*/
+	cause?: string;
+
+	/**
+	The error currently being thrown.
+	*/
+	error?: Error;
+
+	/**
+	The path to the file that raised the error.
+	*/
+	fileName?: string;
+
+	/**
+	The line number where the error occurred.
+	*/
+	lineNumber?: number;
+
+	/**
+	Whether to show relevant properties in the error message details.
+
+	@default true
+	*/
+	showProperties?: boolean;
+
+	/**
+	Whether to show the error stack trace.
+
+	@default false
+	*/
+	showStack?: boolean;
+};
+
+/**
+ * A plugin error
+ * @class
+ * @constructor
+ * @public
+ *
+ * @example
+import {gulpPlugin, PluginError} from 'gulp-plugin-extras';
+
+throw new PluginError('gulpFoo', 'Some error message');
+ */
+export class PluginError extends PluginErrorOptions {
+	constructor(plugin: string | PluginErrorOptions, message: string | Error | PluginErrorOptions, options?: PluginErrorOptions);
+}

--- a/index.js
+++ b/index.js
@@ -39,3 +39,5 @@ export function gulpPlugin(name, onFile, {
 		},
 	);
 }
+
+export {default as PluginError} from './plugin-error.js';

--- a/package.json
+++ b/package.json
@@ -23,8 +23,9 @@
 		"test": "xo && ava && tsc index.d.ts"
 	},
 	"files": [
+		"index.js",
 		"index.d.ts",
-		"index.js"
+		"plugin-error.js"
 	],
 	"keywords": [
 		"gulp",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
 	"type": "module",
 	"exports": {
 		"types": "./index.d.ts",
-		"default": "./index.js"
+		"default": "./index.js",
+		"plugin-error.js": "./plugin-error.js"
 	},
 	"sideEffects": false,
 	"engines": {
@@ -23,8 +24,8 @@
 		"test": "xo && ava && tsc index.d.ts"
 	},
 	"files": [
-		"index.js",
 		"index.d.ts",
+		"index.js",
 		"plugin-error.js"
 	],
 	"keywords": [

--- a/package.json
+++ b/package.json
@@ -13,8 +13,7 @@
 	"type": "module",
 	"exports": {
 		"types": "./index.d.ts",
-		"default": "./index.js",
-		"plugin-error.js": "./plugin-error.js"
+		"default": "./index.js"
 	},
 	"sideEffects": false,
 	"engines": {
@@ -25,8 +24,7 @@
 	},
 	"files": [
 		"index.d.ts",
-		"index.js",
-		"plugin-error.js"
+		"index.js"
 	],
 	"keywords": [
 		"gulp",

--- a/readme.md
+++ b/readme.md
@@ -19,6 +19,7 @@ export default function gulpFoo(requiredArgument) {
 	if (!requiredArgument) {
 		throw new PluginError(pluginName, 'Missing argument `requiredArgumentr`');
 	}
+
 	return gulpPlugin(pluginName, async file => {
 		file.contents = await someKindOfTransformation(file.contents);
 		return file;

--- a/readme.md
+++ b/readme.md
@@ -11,10 +11,15 @@ npm install gulp-plugin-extras
 ## Usage
 
 ```js
-import {gulpPlugin} from 'gulp-plugin-extras';
+import {gulpPlugin, PluginError} from 'gulp-plugin-extras';
 
-export default function gulpFoo() {
-	return gulpPlugin('gulp-foo', async file => {
+const pluginName = 'gulp-foo';
+
+export default function gulpFoo(requiredParam) {
+	if (!requiredParam) {
+		throw new PluginError(pluginName, 'Missing argument `requiredParam`');
+	}
+	return gulpPlugin(pluginName, async file => {
 		file.contents = await someKindOfTransformation(file.contents);
 		return file;
 	});
@@ -89,3 +94,61 @@ export default function gulpFoo() {
 	);
 }
 ```
+
+### `new PluginError(plugin, message, options?)`
+
+Create a Gulp plugin error.
+
+#### plugin
+
+Type: `string`
+
+The plugin name.
+
+#### message
+
+Type: `string`
+
+The error message.
+
+#### options
+
+Type: `object`
+
+##### fileName
+
+Type: `string`
+
+The path to the file that raised the error.
+
+##### lineNumber
+
+Type: `PositiveInteger`
+
+The line number where the error occurred.
+
+##### error
+
+Type: `Error`
+
+The error currently being thrown.
+
+##### cause
+
+Type: `string`
+
+Error cause indicating the reason why the current error is thrown.
+
+##### showProperties
+
+Type: `boolean`\
+Default: `false`
+
+Whether to show relevant properties in the error message details.
+
+##### showStack
+
+Type: `boolean`\
+Default: `false`
+
+Whether to show the error stack trace.

--- a/readme.md
+++ b/readme.md
@@ -96,66 +96,6 @@ export default function gulpFoo() {
 }
 ```
 
-### `new PluginError(plugin: string | PluginErrorOptions, message: string | Error | PluginErrorOptions, options?: PluginErrorOptions)`
+### `PluginError`
 
-Create a Gulp plugin error.
-
-#### plugin
-
-Type: `string | PluginErrorOptions`
-
-The plugin name: either as a plain string or as an option property called `plugin`.
-
-#### message
-
-Type: `string | Error | PluginErrorOptions`
-
-The error message: either a plain string, an Error instance, or as an option property called `message`.
-
-#### options
-
-Type: `object`
-
-##### cause
-
-Type: `string`
-
-Error cause indicating the reason why the current error is thrown.
-
-##### error
-
-Type: `Error`
-
-The error currently being thrown.
-
-##### fileName
-
-Type: `string`
-
-The path to the file that raised the error.
-
-##### lineNumber
-
-Type: `number`
-
-The line number where the error occurred.
-
-##### showProperties
-
-Type: `boolean`\
-Default: `false`
-
-Whether to show relevant properties in the error message details.
-
-##### showStack
-
-Type: `boolean`\
-Default: `false`
-
-Whether to show the error stack trace.
-
-##### stack
-
-Type: `string`
-
-The error stack trace.
+Create a Gulp plugin error. See the [types](index.d.ts) for docs.

--- a/readme.md
+++ b/readme.md
@@ -95,25 +95,37 @@ export default function gulpFoo() {
 }
 ```
 
-### `new PluginError(plugin, message, options?)`
+### `new PluginError(plugin: string | PluginErrorOptions, message: string | Error | PluginErrorOptions, options?: PluginErrorOptions)`
 
 Create a Gulp plugin error.
 
 #### plugin
 
-Type: `string`
+Type: `string | PluginErrorOptions`
 
-The plugin name.
+The plugin name: either as a plain string or as an option property called `plugin`.
 
 #### message
 
-Type: `string`
+Type: `string | Error | PluginErrorOptions`
 
-The error message.
+The error message: either a plain string, an Error instance, or as an option property called `message`.
 
 #### options
 
 Type: `object`
+
+##### cause
+
+Type: `string`
+
+Error cause indicating the reason why the current error is thrown.
+
+##### error
+
+Type: `Error`
+
+The error currently being thrown.
 
 ##### fileName
 
@@ -123,21 +135,9 @@ The path to the file that raised the error.
 
 ##### lineNumber
 
-Type: `PositiveInteger`
+Type: `number`
 
 The line number where the error occurred.
-
-##### error
-
-Type: `Error`
-
-The error currently being thrown.
-
-##### cause
-
-Type: `string`
-
-Error cause indicating the reason why the current error is thrown.
 
 ##### showProperties
 
@@ -152,3 +152,9 @@ Type: `boolean`\
 Default: `false`
 
 Whether to show the error stack trace.
+
+##### stack
+
+Type: `string`
+
+The error stack trace.

--- a/readme.md
+++ b/readme.md
@@ -39,9 +39,9 @@ The plugin name.
 
 #### onFile
 
-Type: `async (file) => file`
+Type: `(file) => file`
 
-The async function called for each [Vinyl file](https://github.com/gulpjs/vinyl) in the stream. Must return a modified or new Vinyl file.
+The function called for each [Vinyl file](https://github.com/gulpjs/vinyl) in the stream. Must return a modified or new Vinyl file. May be async.
 
 #### options
 
@@ -67,7 +67,7 @@ Supersedes `supportsDirectories`.
 
 ##### onFinish
 
-Type: `async function * (stream: NodeJS.ReadableStream): void`
+Type: `async function * (stream: NodeJS.ReadableStream): AsyncGenerator<File, never, void>`
 
 An async generator function executed for finalization after all files have been processed.
 

--- a/readme.md
+++ b/readme.md
@@ -15,9 +15,9 @@ import {gulpPlugin, PluginError} from 'gulp-plugin-extras';
 
 const pluginName = 'gulp-foo';
 
-export default function gulpFoo(requiredParam) {
-	if (!requiredParam) {
-		throw new PluginError(pluginName, 'Missing argument `requiredParam`');
+export default function gulpFoo(requiredArgument) {
+	if (!requiredArgument) {
+		throw new PluginError(pluginName, 'Missing argument `requiredArgumentr`');
 	}
 	return gulpPlugin(pluginName, async file => {
 		file.contents = await someKindOfTransformation(file.contents);


### PR DESCRIPTION
I came across a few typing issues when working with this tool with TypeScript, so I am fixing them here:

- Mark optional types as optional
- Use broader `File` type instead of `File.BufferFile` to be able to work with files of type `File.StreamFile` as well
- Make `onFile` optionally async, i.e. return either `File` or `Promise<File>`
- Improved (hopefully) definition of AsyncGenerator return type

I also would like to be able to work with `PluginError` directly (when performing input checks before creating and returning the plugin itself), so I added it to the `exports` in `package.json`.

Thanks for your consideration! Please let me know if you'd like me to make any changes, or split this into two PRs.